### PR TITLE
Inclusión al menu el offset entre extrusors. 'BCN3D/master'

### DIFF
--- a/BCN3D_DUAL_v3_0_3/Configuration.h
+++ b/BCN3D_DUAL_v3_0_3/Configuration.h
@@ -176,7 +176,7 @@
 #define BANG_MAX 255 // limits current to nozzle while in bang-bang mode; 255=full current
 #define PID_MAX 255 // limits current to nozzle while PID is active (see PID_FUNCTIONAL_RANGE below); 255=full current
 #ifdef PIDTEMP
-  //#define PID_DEBUG // Sends debug data to t    he serial port.
+  //#define PID_DEBUG // Sends debug data to the serial port.
   //#define PID_OPENLOOP 1 // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX
   #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
                                   // is more then PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
@@ -353,7 +353,7 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 
 // default settings
 
-#define DEFAULT_AXIS_STEPS_PER_UNIT   {80,80,2560,458.3}  // default steps per unit for Ultimaker
+#define DEFAULT_AXIS_STEPS_PER_UNIT   {80,80,2133.3,458.3} // {80,80,2560,458.3} // default steps per unit for nuevas barillas BCN3D ALEX
 #define DEFAULT_MAX_FEEDRATE          {250, 250, 3.5, 25}    // (mm/sec)
 #define DEFAULT_MAX_ACCELERATION      {1500,1500,100,100}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
 
@@ -363,8 +363,8 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).
 // For the other hotends it is their distance from the extruder 0 hotend.
-// #define EXTRUDER_OFFSET_X {0.0, 20.00} // (in mm) for each extruder, offset of the hotend on the X axis
-// #define EXTRUDER_OFFSET_Y {0.0, 5.00}  // (in mm) for each extruder, offset of the hotend on the Y axis
+#define EXTRUDER_OFFSET_X {0.0, 51.00, 0.0, 0.0} // (in mm) for each extruder, offset of the hotend on the X axis
+#define EXTRUDER_OFFSET_Y {0.0, 0.90, 0.0, 0.0}  // (in mm) for each extruder, offset of the hotend on the Y
 
 // The speed change that does not require acceleration (i.e. the software might assume it can be done instantaneously)
 #define DEFAULT_XYJERK                5.0// (mm/sec)

--- a/BCN3D_DUAL_v3_0_3/ConfigurationStore.cpp
+++ b/BCN3D_DUAL_v3_0_3/ConfigurationStore.cpp
@@ -8,22 +8,22 @@
 
 void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size)
 {
-    do
-    {
-        eeprom_write_byte((unsigned char*)pos, *value);
-        pos++;
-        value++;
-    }while(--size);
+  do
+  {
+   eeprom_write_byte((unsigned char*)pos, *value);
+   pos++;
+   value++;
+  } while (--size);
 }
 #define EEPROM_WRITE_VAR(pos, value) _EEPROM_writeData(pos, (uint8_t*)&value, sizeof(value))
 void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size)
 {
-    do
-    {
-        *value = eeprom_read_byte((unsigned char*)pos);
-        pos++;
-        value++;
-    }while(--size);
+  do
+  {
+   *value = eeprom_read_byte((unsigned char*)pos);
+   pos++;
+   value++;
+  } while (--size);
 }
 #define EEPROM_READ_VAR(pos, value) _EEPROM_readData(pos, (uint8_t*)&value, sizeof(value))
 //======================================================================================
@@ -39,71 +39,80 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size)
 // the default values are used whenever there is a change to the data, to prevent
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
-#define EEPROM_VERSION "V11"
+
+// #define EEPROM_VERSION "V11"
+#define EEPROM_VERSION "V21"
 
 #ifdef EEPROM_SETTINGS
-void Config_StoreSettings() 
+void Config_StoreSettings()
 {
-  char ver[4]= "000";
-  int i=EEPROM_OFFSET;
-  EEPROM_WRITE_VAR(i,ver); // invalidate data first 
-  EEPROM_WRITE_VAR(i,axis_steps_per_unit);  
-  EEPROM_WRITE_VAR(i,max_feedrate);  
-  EEPROM_WRITE_VAR(i,max_acceleration_units_per_sq_second);
-  EEPROM_WRITE_VAR(i,acceleration);
-  EEPROM_WRITE_VAR(i,retract_acceleration);
-  EEPROM_WRITE_VAR(i,minimumfeedrate);
-  EEPROM_WRITE_VAR(i,mintravelfeedrate);
-  EEPROM_WRITE_VAR(i,minsegmenttime);
-  EEPROM_WRITE_VAR(i,max_xy_jerk);
-  EEPROM_WRITE_VAR(i,max_z_jerk);
-  EEPROM_WRITE_VAR(i,max_e_jerk);
-  EEPROM_WRITE_VAR(i,add_homeing);
-	//Changes Rapduch
-	#ifdef HYSTERESIS_H
-	EEPROM_WRITE_VAR(i,menu_hysteresis_X);
-	EEPROM_WRITE_VAR(i,menu_hysteresis_Y);
-	#endif
-  #ifndef ULTIPANEL
+  char ver[4] = "000";
+  int i = EEPROM_OFFSET;
+  EEPROM_WRITE_VAR(i, ver); // invalidate data first
+  EEPROM_WRITE_VAR(i, axis_steps_per_unit);
+  EEPROM_WRITE_VAR(i, max_feedrate);
+  EEPROM_WRITE_VAR(i, max_acceleration_units_per_sq_second);
+  EEPROM_WRITE_VAR(i, acceleration);
+  EEPROM_WRITE_VAR(i, retract_acceleration);
+  EEPROM_WRITE_VAR(i, minimumfeedrate);
+  EEPROM_WRITE_VAR(i, mintravelfeedrate);
+  EEPROM_WRITE_VAR(i, minsegmenttime);
+  EEPROM_WRITE_VAR(i, max_xy_jerk);
+  EEPROM_WRITE_VAR(i, max_z_jerk);
+  EEPROM_WRITE_VAR(i, max_e_jerk);
+  EEPROM_WRITE_VAR(i, add_homeing);
+  //ALEX
+  float dummy_extruder_offset[][4] = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}};
+#if EXTRUDERS > 1
+  EEPROM_WRITE_VAR(i, extruder_offset); // save extruder offset to the EEPROM memory (from github dob71 MarlinX2)
+#else
+  EEPROM_WRITE_VAR(i, dummy_extruder_offset); // retrieve saved extruder offset (from github dob71 MarlinX2)
+#endif // EXTRUDERS > 1
+  //Changes Rapduch
+#ifdef HYSTERESIS_H
+  EEPROM_WRITE_VAR(i, menu_hysteresis_X);
+  EEPROM_WRITE_VAR(i, menu_hysteresis_Y);
+#endif
+#ifndef ULTIPANEL
   int plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP, plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP, plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED;
   int absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP, absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP, absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
   int nylonPreheatHotendTemp = NYLON_PREHEAT_HOTEND_TEMP, nylonPreheatHPBTemp = NYLON_PREHEAT_HPB_TEMP, nylonPreheatFanSpeed = NYLON_PREHEAT_FAN_SPEED;
   int pvaPreheatHotendTemp = PVA_PREHEAT_HOTEND_TEMP, pvaPreheatHPBTemp = PVA_PREHEAT_HPB_TEMP, pvaPreheatFanSpeed = PVA_PREHEAT_FAN_SPEED;
   //int laywoodPreheatHotendTemp = LAYWOOD_PREHEAT_HOTEND_TEMP, laywoodPreheatHPBTemp = LAYWOOD_PREHEAT_HPB_TEMP, laywoodPreheatFanSpeed = LAYWOOD_PREHEAT_FAN_SPEED;
- // int laybrickPreheatHotendTemp = LAYBRICK_PREHEAT_HOTEND_TEMP, laybrickPreheatHPBTemp = LAYBRICK_PREHEAT_HPB_TEMP, laybrickPreheatFanSpeed = LAYBRICK_PREHEAT_FAN_SPEED;
-  #endif
-  EEPROM_WRITE_VAR(i,plaPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,plaPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,plaPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,absPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,absPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,absPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,nylonPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,nylonPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,nylonPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,pvaPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,pvaPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,pvaPreheatFanSpeed);  
-  EEPROM_WRITE_VAR(i,laywoodPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,laywoodPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,laywoodPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,laybrickPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,laybrickPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,laybrickPreheatFanSpeed);
-  #ifdef PIDTEMP
-    EEPROM_WRITE_VAR(i,Kp);
-    EEPROM_WRITE_VAR(i,Ki);
-    EEPROM_WRITE_VAR(i,Kd);
-  #else
-		float dummy = 3000.0f;
-    EEPROM_WRITE_VAR(i,dummy);
-		dummy = 0.0f;
-    EEPROM_WRITE_VAR(i,dummy);
-    EEPROM_WRITE_VAR(i,dummy);
-  #endif
-  char ver2[4]=EEPROM_VERSION;
-  i=EEPROM_OFFSET;
-  EEPROM_WRITE_VAR(i,ver2); // validate data
+  // int laybrickPreheatHotendTemp = LAYBRICK_PREHEAT_HOTEND_TEMP, laybrickPreheatHPBTemp = LAYBRICK_PREHEAT_HPB_TEMP, laybrickPreheatFanSpeed = LAYBRICK_PREHEAT_FAN_SPEED;
+#endif
+  EEPROM_WRITE_VAR(i, plaPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, plaPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, plaPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, absPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, absPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, absPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, nylonPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, nylonPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, nylonPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, pvaPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, pvaPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, pvaPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, laywoodPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, laywoodPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, laywoodPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, laybrickPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, laybrickPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, laybrickPreheatFanSpeed);
+#ifdef PIDTEMP
+  EEPROM_WRITE_VAR(i, Kp);
+  EEPROM_WRITE_VAR(i, Ki);
+  EEPROM_WRITE_VAR(i, Kd);
+#else
+  float dummy = 3000.0f;
+  EEPROM_WRITE_VAR(i, dummy);
+  dummy = 0.0f;
+  EEPROM_WRITE_VAR(i, dummy);
+  EEPROM_WRITE_VAR(i, dummy);
+#endif
+  char ver2[4] = EEPROM_VERSION;
+  i = EEPROM_OFFSET;
+  EEPROM_WRITE_VAR(i, ver2); // validate data
   SERIAL_ECHO_START;
   SERIAL_ECHOLNPGM("Settings Stored");
 }
@@ -112,212 +121,258 @@ void Config_StoreSettings()
 
 #ifdef EEPROM_CHITCHAT
 void Config_PrintSettings()
-{  // Always have this function, even with EEPROM_SETTINGS disabled, the current values will be shown
+{ // Always have this function, even with EEPROM_SETTINGS disabled, the current values will be shown
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Steps per unit:");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M92 X", axis_steps_per_unit[0]);
+  SERIAL_ECHOPAIR(" Y", axis_steps_per_unit[1]);
+  SERIAL_ECHOPAIR(" Z", axis_steps_per_unit[2]);
+  SERIAL_ECHOPAIR(" E", axis_steps_per_unit[3]);
+  SERIAL_ECHOLN("");
+  // ALEX
+#if EXTRUDERS > 1 // print the extruder offsets (from github dob71 MarlinX2)
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Extruder offset:");
+  for (int i = 0; i < EXTRUDERS; i++)
+  {
     SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Steps per unit:");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M92 X",axis_steps_per_unit[0]);
-    SERIAL_ECHOPAIR(" Y",axis_steps_per_unit[1]);
-    SERIAL_ECHOPAIR(" Z",axis_steps_per_unit[2]);
-    SERIAL_ECHOPAIR(" E",axis_steps_per_unit[3]);
+    SERIAL_ECHOPAIR("   M218 T", float(i));
+    SERIAL_ECHOPAIR(" X", extruder_offset[X_AXIS][i]);
+    SERIAL_ECHOPAIR(" Y", extruder_offset[Y_AXIS][i]);
     SERIAL_ECHOLN("");
-      
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M203 X",max_feedrate[0]);
-    SERIAL_ECHOPAIR(" Y",max_feedrate[1] ); 
-    SERIAL_ECHOPAIR(" Z", max_feedrate[2] ); 
-    SERIAL_ECHOPAIR(" E", max_feedrate[3]);
-    SERIAL_ECHOLN("");
+  }
+#endif // EXTRUDERS > 1
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M201 X" ,max_acceleration_units_per_sq_second[0] ); 
-    SERIAL_ECHOPAIR(" Y" , max_acceleration_units_per_sq_second[1] ); 
-    SERIAL_ECHOPAIR(" Z" ,max_acceleration_units_per_sq_second[2] );
-    SERIAL_ECHOPAIR(" E" ,max_acceleration_units_per_sq_second[3]);
-    SERIAL_ECHOLN("");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Acceleration: S=acceleration, T=retract acceleration");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M204 S",acceleration ); 
-    SERIAL_ECHOPAIR(" T" ,retract_acceleration);
-    SERIAL_ECHOLN("");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M203 X", max_feedrate[0]);
+  SERIAL_ECHOPAIR(" Y", max_feedrate[1] );
+  SERIAL_ECHOPAIR(" Z", max_feedrate[2] );
+  SERIAL_ECHOPAIR(" E", max_feedrate[3]);
+  SERIAL_ECHOLN("");
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), B=minimum segment time (ms), X=maximum XY jerk (mm/s),  Z=maximum Z jerk (mm/s),  E=maximum E jerk (mm/s)");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M205 S",minimumfeedrate ); 
-    SERIAL_ECHOPAIR(" T" ,mintravelfeedrate ); 
-    SERIAL_ECHOPAIR(" B" ,minsegmenttime ); 
-    SERIAL_ECHOPAIR(" X" ,max_xy_jerk ); 
-    SERIAL_ECHOPAIR(" Z" ,max_z_jerk);
-    SERIAL_ECHOPAIR(" E" ,max_e_jerk);
-    SERIAL_ECHOLN(""); 
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M201 X" , max_acceleration_units_per_sq_second[0] );
+  SERIAL_ECHOPAIR(" Y" , max_acceleration_units_per_sq_second[1] );
+  SERIAL_ECHOPAIR(" Z" , max_acceleration_units_per_sq_second[2] );
+  SERIAL_ECHOPAIR(" E" , max_acceleration_units_per_sq_second[3]);
+  SERIAL_ECHOLN("");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Acceleration: S=acceleration, T=retract acceleration");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M204 S", acceleration );
+  SERIAL_ECHOPAIR(" T" , retract_acceleration);
+  SERIAL_ECHOLN("");
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Home offset (mm):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M206 X",add_homeing[0] );
-    SERIAL_ECHOPAIR(" Y" ,add_homeing[1] );
-    SERIAL_ECHOPAIR(" Z" ,add_homeing[2] );
-    SERIAL_ECHOLN("");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), B=minimum segment time (ms), X=maximum XY jerk (mm/s),  Z=maximum Z jerk (mm/s),  E=maximum E jerk (mm/s)");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M205 S", minimumfeedrate );
+  SERIAL_ECHOPAIR(" T" , mintravelfeedrate );
+  SERIAL_ECHOPAIR(" B" , minsegmenttime );
+  SERIAL_ECHOPAIR(" X" , max_xy_jerk );
+  SERIAL_ECHOPAIR(" Z" , max_z_jerk);
+  SERIAL_ECHOPAIR(" E" , max_e_jerk);
+  SERIAL_ECHOLN("");
+
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Home offset (mm):");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("  M206 X", add_homeing[0] );
+  SERIAL_ECHOPAIR(" Y" , add_homeing[1] );
+  SERIAL_ECHOPAIR(" Z" , add_homeing[2] );
+  SERIAL_ECHOLN("");
 #ifdef PIDTEMP
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("PID settings:");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   M301 P",Kp); 
-    SERIAL_ECHOPAIR(" I" ,unscalePID_i(Ki)); 
-    SERIAL_ECHOPAIR(" D" ,unscalePID_d(Kd));
-    SERIAL_ECHOLN(""); 
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("PID settings:");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR("   M301 P", Kp);
+  SERIAL_ECHOPAIR(" I" , unscalePID_i(Ki));
+  SERIAL_ECHOPAIR(" D" , unscalePID_d(Kd));
+  SERIAL_ECHOLN("");
 #endif
-} 
+}
 #endif
 
 
 #ifdef EEPROM_SETTINGS
 void Config_RetrieveSettings()
 {
-    int i=EEPROM_OFFSET;
-    char stored_ver[4];
-    char ver[4]=EEPROM_VERSION;
-    EEPROM_READ_VAR(i,stored_ver); //read stored version
-    //  SERIAL_ECHOLN("Version: [" << ver << "] Stored version: [" << stored_ver << "]");
-    if (strncmp(ver,stored_ver,3) == 0)
-    {
-        // version number match
-        EEPROM_READ_VAR(i,axis_steps_per_unit);  
-        EEPROM_READ_VAR(i,max_feedrate);  
-        EEPROM_READ_VAR(i,max_acceleration_units_per_sq_second);
-        
-        // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
-		reset_acceleration_rates();
-        
-        EEPROM_READ_VAR(i,acceleration);
-        EEPROM_READ_VAR(i,retract_acceleration);
-        EEPROM_READ_VAR(i,minimumfeedrate);
-        EEPROM_READ_VAR(i,mintravelfeedrate);
-        EEPROM_READ_VAR(i,minsegmenttime);
-        EEPROM_READ_VAR(i,max_xy_jerk);
-        EEPROM_READ_VAR(i,max_z_jerk);
-        EEPROM_READ_VAR(i,max_e_jerk);
-        EEPROM_READ_VAR(i,add_homeing);
-		//Changes Rapduch
-		#ifdef HYSTERESIS_H
-		EEPROM_READ_VAR(i,menu_hysteresis_X);
-		EEPROM_READ_VAR(i,menu_hysteresis_Y);
-		#endif
-        #ifndef ULTIPANEL
-        int plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed;
-        int absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed;
-        int nylonPreheatHotendTemp, nylonPreheatHPBTemp, nylonPreheatFanSpeed;
-        int pvaPreheatHotendTemp, pvaPreheatHPBTemp, pvaPreheatFanSpeed;
-        int laywoodPreheatHotendTemp, laywoodPreheatHPBTemp, laywoodPreheatFanSpeed;
-        int laybrickPreheatHotendTemp, laybrickPreheatHPBTemp, laybrickPreheatFanSpeed;
-        #endif
-        EEPROM_READ_VAR(i,plaPreheatHotendTemp);
-        EEPROM_READ_VAR(i,plaPreheatHPBTemp);
-        EEPROM_READ_VAR(i,plaPreheatFanSpeed);
-        EEPROM_READ_VAR(i,absPreheatHotendTemp);
-        EEPROM_READ_VAR(i,absPreheatHPBTemp);
-        EEPROM_READ_VAR(i,absPreheatFanSpeed);
-        EEPROM_READ_VAR(i,nylonPreheatHotendTemp);
-        EEPROM_READ_VAR(i,nylonPreheatHPBTemp);
-        EEPROM_READ_VAR(i,nylonPreheatFanSpeed);
-        EEPROM_READ_VAR(i,pvaPreheatHotendTemp);
-        EEPROM_READ_VAR(i,pvaPreheatHPBTemp);
-        EEPROM_READ_VAR(i,pvaPreheatFanSpeed);
-        EEPROM_READ_VAR(i,laywoodPreheatHotendTemp);
-        EEPROM_READ_VAR(i,laywoodPreheatHPBTemp);
-        EEPROM_READ_VAR(i,laywoodPreheatFanSpeed);
-        EEPROM_READ_VAR(i,laybrickPreheatHotendTemp);
-        EEPROM_READ_VAR(i,laybrickPreheatHPBTemp);
-        EEPROM_READ_VAR(i,laybrickPreheatFanSpeed);
-        #ifndef PIDTEMP
-        float Kp,Ki,Kd;
-        #endif
-        // do not need to scale PID values as the values in EEPROM are already scaled		
-        EEPROM_READ_VAR(i,Kp);
-        EEPROM_READ_VAR(i,Ki);
-        EEPROM_READ_VAR(i,Kd);
+  int i = EEPROM_OFFSET;
+  char stored_ver[4];
+  char ver[4] = EEPROM_VERSION;
+  EEPROM_READ_VAR(i, stored_ver); //read stored version
+  //  SERIAL_ECHOLN("Version: [" << ver << "] Stored version: [" << stored_ver << "]");
+  if (strncmp(ver, stored_ver, 3) == 0)
+  {
+    // version number match
+    EEPROM_READ_VAR(i, axis_steps_per_unit);
+    EEPROM_READ_VAR(i, max_feedrate);
+    EEPROM_READ_VAR(i, max_acceleration_units_per_sq_second);
 
-		// Call updatePID (similar to when we have processed M301)
-		updatePID();
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM("Stored settings retrieved");
-    }
-    else
-    {
-        Config_ResetDefault();
-    }
-    Config_PrintSettings();
+    // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
+    reset_acceleration_rates();
+
+    EEPROM_READ_VAR(i, acceleration);
+    EEPROM_READ_VAR(i, retract_acceleration);
+    EEPROM_READ_VAR(i, minimumfeedrate);
+    EEPROM_READ_VAR(i, mintravelfeedrate);
+    EEPROM_READ_VAR(i, minsegmenttime);
+    EEPROM_READ_VAR(i, max_xy_jerk);
+    EEPROM_READ_VAR(i, max_z_jerk);
+    EEPROM_READ_VAR(i, max_e_jerk);
+    EEPROM_READ_VAR(i, add_homeing);
+    // ALEX
+#if EXTRUDERS > 1
+    EEPROM_READ_VAR(i, extruder_offset); // retrieve saved extruder offset (from github dob71 MarlinX2)
+#endif // EXTRUDERS > 1
+    //Changes Rapduch
+#ifdef HYSTERESIS_H
+    EEPROM_READ_VAR(i, menu_hysteresis_X);
+    EEPROM_READ_VAR(i, menu_hysteresis_Y);
+#endif
+#ifndef ULTIPANEL
+    int plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed;
+    int absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed;
+    int nylonPreheatHotendTemp, nylonPreheatHPBTemp, nylonPreheatFanSpeed;
+    int pvaPreheatHotendTemp, pvaPreheatHPBTemp, pvaPreheatFanSpeed;
+    int laywoodPreheatHotendTemp, laywoodPreheatHPBTemp, laywoodPreheatFanSpeed;
+    int laybrickPreheatHotendTemp, laybrickPreheatHPBTemp, laybrickPreheatFanSpeed;
+#endif
+    EEPROM_READ_VAR(i, plaPreheatHotendTemp);
+    EEPROM_READ_VAR(i, plaPreheatHPBTemp);
+    EEPROM_READ_VAR(i, plaPreheatFanSpeed);
+    EEPROM_READ_VAR(i, absPreheatHotendTemp);
+    EEPROM_READ_VAR(i, absPreheatHPBTemp);
+    EEPROM_READ_VAR(i, absPreheatFanSpeed);
+    EEPROM_READ_VAR(i, nylonPreheatHotendTemp);
+    EEPROM_READ_VAR(i, nylonPreheatHPBTemp);
+    EEPROM_READ_VAR(i, nylonPreheatFanSpeed);
+    EEPROM_READ_VAR(i, pvaPreheatHotendTemp);
+    EEPROM_READ_VAR(i, pvaPreheatHPBTemp);
+    EEPROM_READ_VAR(i, pvaPreheatFanSpeed);
+    EEPROM_READ_VAR(i, laywoodPreheatHotendTemp);
+    EEPROM_READ_VAR(i, laywoodPreheatHPBTemp);
+    EEPROM_READ_VAR(i, laywoodPreheatFanSpeed);
+    EEPROM_READ_VAR(i, laybrickPreheatHotendTemp);
+    EEPROM_READ_VAR(i, laybrickPreheatHPBTemp);
+    EEPROM_READ_VAR(i, laybrickPreheatFanSpeed);
+#ifndef PIDTEMP
+    float Kp, Ki, Kd;
+#endif
+    // do not need to scale PID values as the values in EEPROM are already scaled
+    EEPROM_READ_VAR(i, Kp);
+    EEPROM_READ_VAR(i, Ki);
+    EEPROM_READ_VAR(i, Kd);
+
+    // Call updatePID (similar to when we have processed M301)
+    updatePID();
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM("Stored settings retrieved");
+  }
+  else
+  {
+    Config_ResetDefault();
+  }
+  Config_PrintSettings();
 }
 #endif
 
 void Config_ResetDefault()
 {
-    float tmp1[]=DEFAULT_AXIS_STEPS_PER_UNIT;
-    float tmp2[]=DEFAULT_MAX_FEEDRATE;
-    long tmp3[]=DEFAULT_MAX_ACCELERATION;
-    for (short i=0;i<4;i++) 
+  float tmp1[] = DEFAULT_AXIS_STEPS_PER_UNIT;
+  float tmp2[] = DEFAULT_MAX_FEEDRATE;
+  long tmp3[] = DEFAULT_MAX_ACCELERATION;
+  // ALEX
+#if EXTRUDERS > 1
+  float tmp4[] =
+#ifdef EXTRUDER_OFFSET_X
+    EXTRUDER_OFFSET_X;
+#else
     {
-        axis_steps_per_unit[i]=tmp1[i];  
-        max_feedrate[i]=tmp2[i];  
-        max_acceleration_units_per_sq_second[i]=tmp3[i];
+      0.0, 0.0, 0.0, 0.0
+    };
+#endif // EXTRUDER_OFFSET_X
+  float tmp5[] =
+#ifdef EXTRUDER_OFFSET_Y
+    EXTRUDER_OFFSET_Y;
+#else
+    {
+      0.0, 0.0, 0.0, 0.0
+    };
+#endif // EXTRUDER_OFFSET_Y
+#endif // EXTRUDERS > 1
+
+  for (short i = 0; i < 4; i++)
+  {
+    axis_steps_per_unit[i] = tmp1[i];
+    max_feedrate[i] = tmp2[i];
+    max_acceleration_units_per_sq_second[i] = tmp3[i];
+  
+  // ALEX
+    #if EXTRUDERS > 1
+    if (i < EXTRUDERS)
+    {
+      extruder_offset[X_AXIS][i] = tmp4[i];
+      extruder_offset[Y_AXIS][i] = tmp5[i];
     }
-    
-    // steps per sq second need to be updated to agree with the units per sq second
-    reset_acceleration_rates();
-    
-    acceleration=DEFAULT_ACCELERATION;
-    retract_acceleration=DEFAULT_RETRACT_ACCELERATION;
-    minimumfeedrate=DEFAULT_MINIMUMFEEDRATE;
-    minsegmenttime=DEFAULT_MINSEGMENTTIME;       
-    mintravelfeedrate=DEFAULT_MINTRAVELFEEDRATE;
-    max_xy_jerk=DEFAULT_XYJERK;
-    max_z_jerk=DEFAULT_ZJERK;
-    max_e_jerk=DEFAULT_EJERK;
-    add_homeing[0] = add_homeing[1] = add_homeing[2] = 0;
-	#ifdef HYSTERESIS_H
-	menu_hysteresis_X=X_DEFAULT_HYSTERESIS_MM;
-	menu_hysteresis_Y=Y_DEFAULT_HYSTERESIS_MM;
-	#endif
+  }
+#endif // EXTRUDERS > 1
+
+  // steps per sq second need to be updated to agree with the units per sq second
+  reset_acceleration_rates();
+
+  acceleration = DEFAULT_ACCELERATION;
+  retract_acceleration = DEFAULT_RETRACT_ACCELERATION;
+  minimumfeedrate = DEFAULT_MINIMUMFEEDRATE;
+  minsegmenttime = DEFAULT_MINSEGMENTTIME;
+  mintravelfeedrate = DEFAULT_MINTRAVELFEEDRATE;
+  max_xy_jerk = DEFAULT_XYJERK;
+  max_z_jerk = DEFAULT_ZJERK;
+  max_e_jerk = DEFAULT_EJERK;
+  add_homeing[0] = add_homeing[1] = add_homeing[2] = 0;
+#ifdef HYSTERESIS_H
+  menu_hysteresis_X = X_DEFAULT_HYSTERESIS_MM;
+  menu_hysteresis_Y = Y_DEFAULT_HYSTERESIS_MM;
+#endif
 #ifdef ULTIPANEL
-    plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP;
-    plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP;
-    plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED;
-    absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP;
-    absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP;
-    absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
-    nylonPreheatHotendTemp = NYLON_PREHEAT_HOTEND_TEMP;
-    nylonPreheatHPBTemp = NYLON_PREHEAT_HPB_TEMP;
-    nylonPreheatFanSpeed = NYLON_PREHEAT_FAN_SPEED;
-    pvaPreheatHotendTemp = PVA_PREHEAT_HOTEND_TEMP;
-    pvaPreheatHPBTemp = PVA_PREHEAT_HPB_TEMP;
-    pvaPreheatFanSpeed = PVA_PREHEAT_FAN_SPEED;
-    int laywoodPreheatHotendTemp = LAYWOOD_PREHEAT_HOTEND_TEMP;
-    int laywoodPreheatHPBTemp = LAYWOOD_PREHEAT_HPB_TEMP;
-    int laywoodPreheatFanSpeed = LAYWOOD_PREHEAT_FAN_SPEED;
-    int laybrickPreheatHotendTemp = LAYBRICK_PREHEAT_HOTEND_TEMP;
-    int laybrickPreheatHPBTemp = LAYBRICK_PREHEAT_HPB_TEMP;
-    int laybrickPreheatFanSpeed = LAYBRICK_PREHEAT_FAN_SPEED;
+  plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP;
+  plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP;
+  plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED;
+  absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP;
+  absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP;
+  absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
+  nylonPreheatHotendTemp = NYLON_PREHEAT_HOTEND_TEMP;
+  nylonPreheatHPBTemp = NYLON_PREHEAT_HPB_TEMP;
+  nylonPreheatFanSpeed = NYLON_PREHEAT_FAN_SPEED;
+  pvaPreheatHotendTemp = PVA_PREHEAT_HOTEND_TEMP;
+  pvaPreheatHPBTemp = PVA_PREHEAT_HPB_TEMP;
+  pvaPreheatFanSpeed = PVA_PREHEAT_FAN_SPEED;
+  int laywoodPreheatHotendTemp = LAYWOOD_PREHEAT_HOTEND_TEMP;
+  int laywoodPreheatHPBTemp = LAYWOOD_PREHEAT_HPB_TEMP;
+  int laywoodPreheatFanSpeed = LAYWOOD_PREHEAT_FAN_SPEED;
+  int laybrickPreheatHotendTemp = LAYBRICK_PREHEAT_HOTEND_TEMP;
+  int laybrickPreheatHPBTemp = LAYBRICK_PREHEAT_HPB_TEMP;
+  int laybrickPreheatFanSpeed = LAYBRICK_PREHEAT_FAN_SPEED;
 #endif
 #ifdef PIDTEMP
-    Kp = DEFAULT_Kp;
-    Ki = scalePID_i(DEFAULT_Ki);
-    Kd = scalePID_d(DEFAULT_Kd);
-    
-    // call updatePID (similar to when we have processed M301)
-    updatePID();
-    
+  Kp = DEFAULT_Kp;
+  Ki = scalePID_i(DEFAULT_Ki);
+  Kd = scalePID_d(DEFAULT_Kd);
+
+  // call updatePID (similar to when we have processed M301)
+  updatePID();
+
 #ifdef PID_ADD_EXTRUSION_RATE
-    Kc = DEFAULT_Kc;
+  Kc = DEFAULT_Kc;
 #endif//PID_ADD_EXTRUSION_RATE
 #endif//PIDTEMP
 
-SERIAL_ECHO_START;
-SERIAL_ECHOLNPGM("Hardcoded Default Settings Loaded");
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Hardcoded Default Settings Loaded");
 
 }

--- a/BCN3D_DUAL_v3_0_3/Marlin.h
+++ b/BCN3D_DUAL_v3_0_3/Marlin.h
@@ -210,5 +210,6 @@ extern unsigned long stoptime;
 
 // Handling multiple extruders pins
 extern uint8_t active_extruder;
-
+//KK ALEX A SOLUCIONAR ON DECALAR AQUESTA MATRIU
+extern float extruder_offset[2][4];
 #endif

--- a/BCN3D_DUAL_v3_0_3/Marlin_main.cpp
+++ b/BCN3D_DUAL_v3_0_3/Marlin_main.cpp
@@ -167,14 +167,33 @@ float current_position[NUM_AXIS] = { 0.0, 0.0, 0.0, 0.0 };
 float add_homeing[3]={0,0,0};
 float min_pos[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
 float max_pos[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
+
 // Extruder offset, only in XY plane
+//#if EXTRUDERS > 1
+//float extruder_offset[2][EXTRUDERS] = {
+//#if defined(EXTRUDER_OFFSET_X) && defined(EXTRUDER_OFFSET_Y)
+//  EXTRUDER_OFFSET_X, EXTRUDER_OFFSET_Y
+//#endif
+//};
+//#endif
+// ALEX
 #if EXTRUDERS > 1
-float extruder_offset[2][EXTRUDERS] = {
-#if defined(EXTRUDER_OFFSET_X) && defined(EXTRUDER_OFFSET_Y)
-  EXTRUDER_OFFSET_X, EXTRUDER_OFFSET_Y
+   //extern float extruder_offset[2][4]; // 4 extruder offsets for future expandability
+   #ifndef EXTRUDER_OFFSET_X
+      #define EXTRUDER_OFFSET_X { 0.0, 0.0, 0.0, 0.0 } // 4 extruder offsets for future expandability
+   #endif
+   #ifndef EXTRUDER_OFFSET_Y
+      #define EXTRUDER_OFFSET_Y { 0.0, 0.0, 0.0, 0.0 }
+   #endif
+   float extruder_offset[][4] = {
+     EXTRUDER_OFFSET_X,
+     EXTRUDER_OFFSET_Y
+     //#if ENABLED(DUAL_X_CARRIAGE)
+     //  , { 0 } // supports offsets in XYZ plane
+     //#endif
+   };
 #endif
-};
-#endif
+
 uint8_t active_extruder = 0;
 int fanSpeed=0;
 #ifdef SERVO_ENDSTOPS

--- a/BCN3D_DUAL_v3_0_3/dogm_lcd_implementation.h
+++ b/BCN3D_DUAL_v3_0_3/dogm_lcd_implementation.h
@@ -124,7 +124,7 @@ static void lcd_implementation_init()
                       	
 			//Rapduch
 			u8g.setPrintPos(83,51);
-			u8g.print("v3.0.3");
+			u8g.print("v3.1.3");
 						  
 				/*
             u8g.drawStr(62,10,"MARLIN"); 

--- a/BCN3D_DUAL_v3_0_3/language.h
+++ b/BCN3D_DUAL_v3_0_3/language.h
@@ -19,7 +19,7 @@
 // 10 Catalan
 
 #ifndef LANGUAGE_CHOICE
-#define LANGUAGE_CHOICE 1  // Pick your language from the list above
+#define LANGUAGE_CHOICE 1  // Pick your language from the list above ALEX NO ES POT CAMBIAR error compilació
 #endif
 
 #define PROTOCOL_VERSION "1.0"
@@ -119,6 +119,25 @@
 	#define MSG_YSTEPS "Ysteps/mm"
 	#define MSG_ZSTEPS "Zsteps/mm"
 	#define MSG_ESTEPS "Esteps/mm"
+  // ALEX
+  #ifndef MSG_X1OFFSET
+#define MSG_X1OFFSET                         "T1X Offset"
+#endif
+#ifndef MSG_Y1OFFSET
+#define MSG_Y1OFFSET                         "T1Y Offset"
+#endif
+#ifndef MSG_X2OFFSET
+#define MSG_X2OFFSET                         "T2X Offset"
+#endif
+#ifndef MSG_Y2OFFSET
+#define MSG_Y2OFFSET                         "T2Y Offset"
+#endif
+#ifndef MSG_X3OFFSET
+#define MSG_X3OFFSET                         "T3X Offset"
+#endif
+#ifndef MSG_Y3OFFSET
+#define MSG_Y3OFFSET                         "T3Y Offset"
+#endif
 	#define MSG_RECTRACT "Rectract"
 	#define MSG_TEMPERATURE "Temperature"
 	#define MSG_MOTION "Motion"

--- a/BCN3D_DUAL_v3_0_3/ultralcd.cpp
+++ b/BCN3D_DUAL_v3_0_3/ultralcd.cpp
@@ -378,6 +378,7 @@ void lcd_preheat_filaflex()
 {
 	setTargetHotend0(FILAFLEX_PREHEAT_HOTEND_TEMP);
 	setTargetHotend1(FILAFLEX_PREHEAT_HOTEND_TEMP);
+	setTargetHotend2(FILAFLEX_PREHEAT_HOTEND_TEMP);
 	setTargetBed(FILAFLEX_PREHEAT_HPB_TEMP);
 	fanSpeed = FILAFLEX_PREHEAT_FAN_SPEED;
 	lcd_return_to_status();
@@ -524,9 +525,9 @@ void lcd_preheat_laybrick_hb()
     setWatch(); // heater sanity check timer
 }
 
-void lcd_preheat_filaflex_hb()
+void lcd_preheat_filaflex_hb() 
 {
-	setTargetBed(FILAFLEX_PREHEAT_HPB_TEMP);
+	setTargetBed(FILAFLEX_PREHEAT_HPB_TEMP); // FIXED
 	lcd_return_to_status();
 	setWatch(); // heater sanity check timer
 }
@@ -535,6 +536,7 @@ static void lcd_cooldown()
 {
     setTargetHotend0(0);
     setTargetHotend1(0);
+    setTargetHotend2(0);
     setTargetBed(0);
     lcd_return_to_status();
 }
@@ -644,7 +646,7 @@ static void lcd_preheat_hb_menu()
     MENU_ITEM(function, MSG_PREHEAT_PVA, lcd_preheat_pla_hb);
     MENU_ITEM(function, MSG_PREHEAT_LAYWOOD, lcd_preheat_laywood_hb);
     MENU_ITEM(function, MSG_PREHEAT_LAYBRICK, lcd_preheat_laybrick_hb);
-	MENU_ITEM(function, MSG_PREHEAT_FILAFLEX, lcd_preheat_filaflex_hb);
+	  MENU_ITEM(function, MSG_PREHEAT_FILAFLEX, lcd_preheat_filaflex_hb);
     END_MENU();
 }
 
@@ -814,13 +816,13 @@ static void lcd_control_menu()
     MENU_ITEM(back, MSG_MAIN, lcd_main_menu);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
     MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
-#ifdef FWRETRACT
+    #ifdef FWRETRACT
     MENU_ITEM(submenu, MSG_RETRACT, lcd_control_retract_menu);
-#endif
-#ifdef EEPROM_SETTINGS
+    #endif
+    #ifdef EEPROM_SETTINGS
     MENU_ITEM(function, MSG_STORE_EPROM, Config_StoreSettings);
     MENU_ITEM(function, MSG_LOAD_EPROM, Config_RetrieveSettings);
-#endif
+    #endif
     MENU_ITEM(function, MSG_RESTORE_FAILSAFE, Config_ResetDefault);
     END_MENU();
 }
@@ -922,6 +924,19 @@ static void lcd_control_motion_menu()
     MENU_ITEM_EDIT(float52, MSG_YSTEPS, &axis_steps_per_unit[Y_AXIS], 5, 9999);
     MENU_ITEM_EDIT(float51, MSG_ZSTEPS, &axis_steps_per_unit[Z_AXIS], 5, 9999);
     MENU_ITEM_EDIT(float51, MSG_ESTEPS, &axis_steps_per_unit[E_AXIS], 5, 9999);    
+    // ALEX
+    #if EXTRUDERS > 1
+    MENU_ITEM_EDIT(float52, MSG_X1OFFSET, &extruder_offset[X_AXIS][1], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y1OFFSET, &extruder_offset[Y_AXIS][1], -200, 200);
+  #endif // EXTRUDERS > 1
+  #if EXTRUDERS > 2
+    MENU_ITEM_EDIT(float52, MSG_X2OFFSET, &extruder_offset[X_AXIS][2], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y2OFFSET, &extruder_offset[Y_AXIS][2], -200, 200);
+  #endif // EXTRUDERS > 2
+  #if EXTRUDERS > 3
+    MENU_ITEM_EDIT(float52, MSG_X3OFFSET, &extruder_offset[X_AXIS][3], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y3OFFSET, &extruder_offset[Y_AXIS][3], -200, 200);
+  #endif // EXTRUDERS > 3
 #ifdef ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
     MENU_ITEM_EDIT(bool, "Endstop abort", &abort_on_endstop_hit);
 #endif

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@ Dual-Extruder-Firmware
 ======================
 
 Two materials, two colors, support material... Easy! with the dual extruder configuration for your BCN3D+
+And offset between extrusors saved at eeprom so yo dont need to change on slicer


### PR DESCRIPTION
Inclusión de menu per el offset entre extrusors.
D’aquesta manera el g-code generat en una maquina es pot imprimir a qualsevol printer que tinguin offset diferents.
Naturalmente al Cura o alltre soft s’ha d’informar a 0 els offsets. 

Testejat i funciona.
